### PR TITLE
Us os when creating output files and folders

### DIFF
--- a/matchmaking/calculate-distances.py
+++ b/matchmaking/calculate-distances.py
@@ -1,9 +1,9 @@
 import argparse
 import json
 import numpy as np
+import os
 import pandas as pd
 import pickle
-import subprocess
 
 import models as models
 from metrics import Metrics
@@ -64,7 +64,10 @@ def main(inputs, samples, seed=SEED, output_directory="outputs"):
     labeled = pd.concat([distances, inputs['labels'], inputs['features']], axis=1)
 
     evaluated_models_dictionary = Metrics.evaluate_models(samples, labeled, model_names, model_descriptions)
-    write_pickle(f'{output_directory}/models.evaluated.pkl', evaluated_models_dictionary)
+    write_pickle(
+        handle=os.path.join(output_directory, 'models.evaluated.pkl'),
+        output=evaluated_models_dictionary
+    )
     AveragePrecision.plot(evaluated_models_dictionary, model_names, output_directory)
     AveragePrecisionK.plot(evaluated_models_dictionary, model_names, output_directory)
 
@@ -78,11 +81,15 @@ def main(inputs, samples, seed=SEED, output_directory="outputs"):
         ]
 
         df = evaluated_models_dictionary[model.label]['calculated']
-        (df
-         .reset_index()
-         .loc[:, output_columns]
-         .to_csv(f'{output_directory}/models/{model.label}.fully_annotated.result.txt', sep='\t')
-         )
+        (
+            df
+            .reset_index()
+            .loc[:, output_columns]
+            .to_csv(
+                os.path.join(output_directory, 'models', f'{model.label}.fully_annotated.result.txt'),
+                sep='\t'
+            )
+        )
 
 
 if __name__ == "__main__":
@@ -146,9 +153,24 @@ if __name__ == "__main__":
         inputs_dictionary[data_type] = dataframe
 
     output_directory = config['output_directory']
-    subprocess.call(f"mkdir -p {output_directory}", shell=True)
-    subprocess.call(f"mkdir -p {output_directory}/distances", shell=True)
-    subprocess.call(f"mkdir -p {output_directory}/features", shell=True)
-    subprocess.call(f"mkdir -p {output_directory}/img", shell=True)
-    subprocess.call(f"mkdir -p {output_directory}/models", shell=True)
+    os.makedirs(
+        name=output_directory,
+        exist_ok=True
+    )
+    os.makedirs(
+        name=os.path.join(output_directory, 'distances'),
+        exist_ok=True
+    )
+    os.makedirs(
+        name=os.path.join(output_directory, 'features'),
+        exist_ok=True
+    )
+    os.makedirs(
+        name=os.path.join(output_directory, 'img'),
+        exist_ok=True
+    )
+    os.makedirs(
+        name=os.path.join(output_directory, 'models'),
+        exist_ok=True
+    )
     main(inputs=inputs_dictionary, samples=samples_to_use, output_directory=output_directory)

--- a/matchmaking/compare-models.py
+++ b/matchmaking/compare-models.py
@@ -1,5 +1,6 @@
 import argparse
 import numpy as np
+import os
 import pandas as pd
 import pickle
 
@@ -96,7 +97,8 @@ if __name__ == "__main__":
 
     models = read_pickle(args.input)
     summary = summarize_models(models)
-    write_file(summary, f"{args.output_directory}/models.summary.txt")
+
+    write_file(summary, handle=os.path.join(args.output_directory, 'models.summary.txt'))
 
     model_pairwise_comparison = compare_all_models(models)
-    write_file(model_pairwise_comparison, f"{args.output_directory}/models.pairwise-comparison.txt")
+    write_file(model_pairwise_comparison, handle=os.path.join(args.output_directory, 'models.pairwise-comparison.txt'))

--- a/matchmaking/evaluate-models.py
+++ b/matchmaking/evaluate-models.py
@@ -50,7 +50,7 @@ def main(samples, distances, labels, output_directory, features=None, seed=42):
     np.random.seed(seed=seed)
 
     labeled = merge_dataframes(distances.reset_index(), labels.reset_index(), ['case', 'comparison'])
-    if features:
+    if features is not None:
         labeled = merge_dataframes(labeled.reset_index(), features.reset_index(), ['case', 'comparison'])
 
     model_names = distances.columns.tolist()
@@ -68,7 +68,7 @@ def main(samples, distances, labels, output_directory, features=None, seed=42):
 
     for model_name in model_names:
         print(model_name)
-        if features:
+        if features is not None:
             output_columns = [
                 'case', 'comparison',
                 model_name, 'k', 'p@k', 'r@k', 'tps@k',

--- a/matchmaking/evaluate-models.py
+++ b/matchmaking/evaluate-models.py
@@ -1,5 +1,6 @@
 import argparse
 import numpy as np
+import os
 import pandas as pd
 import pickle
 import subprocess
@@ -58,7 +59,10 @@ def main(samples, distances, labels, output_directory, features=None, seed=42):
         model_descriptions[model_name] = ""
 
     evaluated_models_dictionary = Metrics.evaluate_models(samples, labeled, model_names, model_descriptions)
-    write_pickle(f'{output_directory}/models.evaluated.pkl', evaluated_models_dictionary)
+    write_pickle(
+        handle=os.path.join(output_directory, 'models.evaluated.pkl'),
+        output=evaluated_models_dictionary
+    )
     AveragePrecision.plot(evaluated_models_dictionary, model_names, output_directory)
     AveragePrecisionK.plot(evaluated_models_dictionary, model_names, output_directory)
 
@@ -82,11 +86,16 @@ def main(samples, distances, labels, output_directory, features=None, seed=42):
             ]
 
         df = evaluated_models_dictionary[model_name]['calculated']
-        (df
-         .reset_index()
-         .loc[:, output_columns]
-         .to_csv(f'{output_directory}/models/{model_name}.fully_annotated.result.txt', sep='\t', index=False)
-         )
+        (
+            df
+            .reset_index()
+            .loc[:, output_columns]
+            .to_csv(
+                os.path.join(output_directory, 'models', f'{model_name}.fully_annotated.result.txt'),
+                sep='\t',
+                index=False
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/matchmaking/inputs/annotated/annotate-copy-numbers.py
+++ b/matchmaking/inputs/annotated/annotate-copy-numbers.py
@@ -1,6 +1,7 @@
 # RUN THIS FROM moalmanac/moalmanac
 
 import argparse
+import os
 import pandas as pd
 
 import annotator
@@ -178,5 +179,5 @@ if __name__ == "__main__":
                    'evidence', 'cancerhotspots_bin', 'cancerhotspots3D_bin', 'cgc_bin',
                    'cosmic_bin', 'gsea_pathways_bin', 'gsea_modules_bin']
 
-    output = f"{args.directory}/{args.output}"
+    output = os.path.join(args.directory, args.output)
     write_df(dataframe, output, use_columns)

--- a/matchmaking/inputs/annotated/annotate-fusions.py
+++ b/matchmaking/inputs/annotated/annotate-fusions.py
@@ -3,6 +3,7 @@
 
 import time
 import argparse
+import os
 import pandas as pd
 
 import annotator
@@ -320,7 +321,7 @@ if __name__ == "__main__":
                    'evidence', 'cancerhotspots_bin', 'cancerhotspots3D_bin', 'cgc_bin',
                    'cosmic_bin', 'gsea_pathways_bin', 'gsea_modules_bin']
 
-    output = f"{args.directory}/{args.output}"
+    output = os.path.join(args.directory, args.output)
     write_df(both_genes, output, use_columns)
 
     use_columns.remove('which_match')

--- a/matchmaking/inputs/annotated/annotate-variants.py
+++ b/matchmaking/inputs/annotated/annotate-variants.py
@@ -1,6 +1,7 @@
 # RUN THIS FROM moalmanac/moalmanac
 
 import argparse
+import os
 import pandas as pd
 
 import annotator
@@ -201,5 +202,5 @@ if __name__ == "__main__":
                    'evidence', 'cancerhotspots_bin', 'cancerhotspots3D_bin', 'cgc_bin',
                    'cosmic_bin', 'gsea_pathways_bin', 'gsea_modules_bin']
 
-    output = f"{args.directory}/{args.output}"
+    output = os.path.join(args.directory, args.output)
     write_df(dataframe, output, use_columns)

--- a/matchmaking/models.py
+++ b/matchmaking/models.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 from sklearn import neighbors
 import sklearn
@@ -65,7 +66,11 @@ class Models:
         # stacked.drop_duplicates(subset=[cls.case, cls.comparison], keep='first', inplace=True)
         stacked.rename(columns={'level_0': cls.case, 'level_1': cls.comparison, 0: label}, inplace=True)
 
-        stacked.to_csv(f'{output_directory}/distances/{label}.stacked.txt', sep='\t', index=False)
+        stacked.to_csv(
+            path_or_buf=os.path.join(output_directory, 'distances', f'{label}.stacked.txt'),
+            sep='\t',
+            index=False
+        )
         stacked.set_index([cls.case, cls.comparison], inplace=True)
         return stacked.loc[stacked.index, label]
 
@@ -218,7 +223,10 @@ class AlmanacFeatures(Almanac):
         distance_dataframe = cls.calculate_distance(boolean_dataframe, cls.jaccard.pairwise)
         stacked_dataframe = cls.stack_distances(distance_dataframe, cls.label, output_directory)
 
-        boolean_dataframe.to_csv(f'{output_directory}/features/{cls.label_output}.boolean.txt', sep='\t')
+        boolean_dataframe.to_csv(
+            path_or_buf=os.path.join(output_directory, 'features', f'{cls.label_output}.boolean.txt'),
+            sep='\t'
+        )
         return stacked_dataframe
 
     @classmethod
@@ -327,7 +335,10 @@ class AlmanacFeatureTypes(Almanac):
         distance_dataframe = cls.calculate_distance(boolean_dataframe, cls.jaccard.pairwise)
         stacked_dataframe = cls.stack_distances(distance_dataframe, cls.label, output_directory)
 
-        boolean_dataframe.to_csv(f'{output_directory}/features/{cls.label_output}.boolean.txt', sep='\t')
+        boolean_dataframe.to_csv(
+            path_or_buf=os.path.join(output_directory, 'features', f'{cls.label_output}.boolean.txt'),
+            sep='\t'
+        )
         return stacked_dataframe
 
     @classmethod
@@ -368,7 +379,10 @@ class AlmanacGenes(Almanac):
         distance_dataframe = cls.calculate_distance(boolean_dataframe, cls.jaccard.pairwise)
         stacked_dataframe = cls.stack_distances(distance_dataframe, cls.label, output_directory)
 
-        boolean_dataframe.to_csv(f'{output_directory}/features/{cls.label_output}.boolean.txt', sep='\t')
+        boolean_dataframe.to_csv(
+            path_or_buf=os.path.join(output_directory, 'features', f'{cls.label_output}.boolean.txt'),
+            sep='\t'
+        )
         return stacked_dataframe
 
     @classmethod
@@ -436,7 +450,10 @@ class CGC(Models):
         distance_dataframe = cls.calculate_distance(boolean_dataframe, cls.jaccard.pairwise)
         stacked_dataframe = cls.stack_distances(distance_dataframe, cls.label, output_directory)
 
-        boolean_dataframe.to_csv(f'{output_directory}/features/{cls.label_output}.boolean.txt', sep='\t')
+        boolean_dataframe.to_csv(
+            path_or_buf=os.path.join(output_directory, 'features', f'{cls.label_output}.boolean.txt'),
+            sep='\t'
+        )
         return stacked_dataframe
 
     @classmethod
@@ -488,7 +505,10 @@ class CGCFeatureTypes(Models):
         distance_dataframe = cls.calculate_distance(boolean_dataframe, cls.jaccard.pairwise)
         stacked_dataframe = cls.stack_distances(distance_dataframe, cls.label, output_directory)
 
-        boolean_dataframe.to_csv(f'{output_directory}/features/{cls.label_output}.boolean.txt', sep='\t')
+        boolean_dataframe.to_csv(
+            path_or_buf=os.path.join(output_directory, 'features', f'{cls.label_output}.boolean.txt'),
+            sep='\t'
+        )
         return stacked_dataframe
 
     @classmethod
@@ -565,7 +585,11 @@ class Compatibility(Almanac):
         distance_dataframe.index = distance_dataframe.index.tolist()
         stacked_dataframe = cls.stack_distances(distance_dataframe, cls.label, output_directory)
 
-        distance_dataframe.to_csv(f'{output_directory}/distances/{cls.label_output}.txt', sep='\t', index=False)
+        distance_dataframe.to_csv(
+            path_or_buf=os.path.join(output_directory, 'distances', f'{cls.label_output}.txt'),
+            sep='\t',
+            index=False
+        )
         return stacked_dataframe
 
     @classmethod
@@ -792,7 +816,10 @@ class NonsynVariantCount(Models):
         distance_dataframe = cls.create_difference_dataframe(counts_series)
         stacked_dataframe = cls.stack_distances(distance_dataframe, cls.label, output_directory)
 
-        counts_series.to_csv(f'{output_directory}/features/{cls.label_output}.txt', sep='\t')
+        counts_series.to_csv(
+            path_or_buf=os.path.join(output_directory, 'features', f'{cls.label_output}.txt'),
+            sep='\t'
+        )
         return stacked_dataframe
 
     @staticmethod
@@ -916,7 +943,10 @@ class RelativeSubstitutionRates(Models):
         distance_dataframe = cls.create_difference_dataframe(counts_series)
         stacked_dataframe = cls.stack_distances(distance_dataframe, cls.label, output_directory)
 
-        counts_series.to_csv(f'{output_directory}/features/{cls.label_output}.txt', sep='\t')
+        counts_series.to_csv(
+            path_or_buf=os.path.join(output_directory, 'features', f'{cls.label_output}.txt'),
+            sep='\t'
+        )
         return stacked_dataframe
 
     @staticmethod

--- a/matchmaking/plots.py
+++ b/matchmaking/plots.py
@@ -1,5 +1,6 @@
 import matplotlib.cm
 import matplotlib.pyplot as plt
+import os
 import pandas as pd
 import seaborn as sns
 
@@ -38,7 +39,11 @@ class AveragePrecision(Plots):
 
         # plt.title("Boxplot with jitter", loc="left")
         plt.xticks(rotation=45, fontsize=14, ha='right')
-        plt.savefig(f'{output_directory}/img/{outname}.avg_precision.png', bbox_inches='tight', dpi=300)
+        plt.savefig(
+            fname=os.path.join(output_directory, 'img', f'{outname}.avg_precision.png'),
+            bbox_inches='tight',
+            dpi=300
+        )
 
 
 class AveragePrecisionK(Plots):
@@ -67,4 +72,8 @@ class AveragePrecisionK(Plots):
         ax.set_xlabel('Rank (k)', fontsize=16)
         ax.set_title('Average Precision @ K performance', fontsize=18)
         ax.legend(fontsize=14, frameon=False)
-        plt.savefig(f'{output_directory}/img/{outname}.avg_precision_at_k.png', bbox_inches='tight', dpi=300)
+        plt.savefig(
+            fname=os.path.join(output_directory, 'img', f'{outname}.avg_precision_at_k.png'),
+            bbox_inches='tight',
+            dpi=300
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ipykernel==6.6.0
+ipykernel==6.29.5
 matplotlib==3.10.0
 numpy==2.2.0
 pandas==2.2.3


### PR DESCRIPTION
Use `os.path.join` to create output file paths within:
- matchmaking/calculate-distances.py
- matchmaking/compare-models.py
- matchmaking/evaluate-models.py
- matchmaking/models.py
- matchmaking/plots.py
- matchmaking/inputs/annotated/annotate-copy-numbers.py
- matchmaking/inputs/annotated/annotate-fusions.py
- matchmaking/inputs/annotated/annotate-variants.py

Use `os.makedirs` instead of `subprocess` to create directories in:
- matchmaking/calculate-distances.py

Changed logic to use `if features is not None` instead of `if features` in matchmaking/evaluate-models.py.

Updated ipython version in requirements.txt to 6.29.5